### PR TITLE
whereType is better

### DIFF
--- a/examples/misc/lib/effective_dart/usage_bad.dart
+++ b/examples/misc/lib/effective_dart/usage_bad.dart
@@ -61,7 +61,7 @@ void miscDeclAnalyzedButNotTested() {
   {
     // #docregion where-type
     var objects = [1, "a", 2, "b", 3];
-    var ints = objects.where((e) => e is int);
+    var ints = objects.whereType<int>();
     // #enddocregion where-type
   }
 

--- a/examples_archive/library_tour/mirrors/bin/main.dart
+++ b/examples_archive/library_tour/mirrors/bin/main.dart
@@ -55,7 +55,7 @@ void showConstructors(ClassMirror mirror) {
 }
 
 void showFields(ClassMirror mirror) {
-  var fields = mirror.declarations.values.where((m) => m is VariableMirror);
+  var fields = mirror.declarations.values.whereType<VariableMirror>();
 
   fields.forEach((m) {
     VariableMirror v = m as VariableMirror;


### PR DESCRIPTION
whereType is better (https://www.dartlang.org/guides/language/effective-dart/usage#do-use-wheretype-to-filter-a-collection-by-type)